### PR TITLE
fixes photonception issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var mappings = {
 function photon (imageUrl, opts) {
 
   // strip any leading `http(s)://`
-  imageUrl = imageUrl.replace(/^https?\:\/\//i, '');
+  imageUrl = imageUrl.replace(/^https?\:\/\/(i\d.wp.com\/)?/i, '');
 
   // determine which Photon server to connect to: `i0`, `i1`, or `i2`.
   // statically hash the subdomain based on the URL, to optimize browser caches.

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ describe('photon()', function () {
   });
 
   it('should not Photon-ify a Photon URL', function () {
-    var url = 'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
+    var url = 'https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
     assert(photon(url) === url);
   });
 });


### PR DESCRIPTION
I noticed two issues. The first is that the photon subdomain for the image in the photon-ception test seems to be incorrect. If I feed

> http://www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc 

into photon, it returns 

> https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc

and not

> https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc

as the test was running against. Fixing that shows that the test fails and photon-ception is still possible. And that's because when generating the photon server (`i0`, `i1`, or `i2`), we were not first removing the possible pre-pended photon subdomain. So in this case we were determining the photon subdomain from

> i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc

instead of

> www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc

So I'm also stripping any possible photon subdomain before generating the resulting subdomain, so we're comparing apples to apples.
