### PR TITLE
Fix how querystrings are dealt with for photon hosts, protcolless urls.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,22 +41,27 @@ var mappings = {
 
 function photon (imageUrl, opts) {
 
-  // strip any leading `http(s)://`
-  imageUrl = imageUrl.replace(/^https?\:\/\/(i\d.wp.com\/)?/i, '');
+  // parse the URL, assuming //host.com/path style URLs are ok and parse the querystring
+  var parsedUrl = url.parse( imageUrl, true, true );
 
-  // determine which Photon server to connect to: `i0`, `i1`, or `i2`.
-  // statically hash the subdomain based on the URL, to optimize browser caches.
-  var hash = crc32(imageUrl);
-  var rng = seed(hash);
-  var server = 'i' + Math.floor(rng() * 3);
-  debug('determined server "%s" to use with "%s"', server, imageUrl);
+  delete parsedUrl.protocol;
+  delete parsedUrl.auth;
+  delete parsedUrl.port;
 
   var params = {
     slashes: true,
-    pathname: imageUrl,
-    protocol: 'https:',
-    hostname: server + '.wp.com'
+    protocol: 'https:'
   };
+
+  if ( isAlreadyPhotoned( parsedUrl.host ) ) {
+    // We already have a server to use.
+    // Use it, even if it doesn't match our hash.
+    params.pathname = parsedUrl.pathname;
+    params.hostname = parsedUrl.hostname;
+  } else {
+    params.pathname = url.format( parsedUrl ).substring(1);
+    params.hostname = serverFromPathname( params.pathname );
+  }
 
   if (opts) {
     for (var i in opts) {
@@ -80,15 +85,27 @@ function photon (imageUrl, opts) {
     }
   }
 
-  // prevent inception (attempting to Photon-ify a link that
-  // already is already pointing to the Photon hostname)
-  var h = params.hostname + '/';
-  if (0 === params.pathname.indexOf(h)) {
-    debug('preventing Photon URL "inception", stripping leading "%s"', h);
-    params.pathname = params.pathname.substring(h.length);
-  }
-
   var photonUrl = url.format(params);
   debug('generated Photon URL: %s', photonUrl);
   return photonUrl;
 }
+
+function isAlreadyPhotoned( host ) {
+  return /^i[0-2]\.wp\.com$/.test(host);
+}
+
+/**
+ * Determine which Photon server to connect to: `i0`, `i1`, or `i2`.
+ *
+ * Statically hash the subdomain based on the URL, to optimize browser caches.
+ * @param  {string} pathname The pathname to use
+ * @return {string}          The hostname for the pathname
+ */
+function serverFromPathname( pathname ) {
+  var hash = crc32(pathname);
+  var rng = seed(hash);
+  var server = 'i' + Math.floor(rng() * 3);
+  debug('determined server "%s" to use with "%s"', server, pathname);
+  return server + '.wp.com';
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photon",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "JavaScript library for the WordPress.com Photon image manipulation service",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -5,20 +5,105 @@
 
 var photon = require('../');
 var assert = require('assert');
+var parseUrl = require('url').parse;
+
+function assertHostedOnPhoton( url ) {
+  assert(RegExp('^https://i[0-2].wp.com').test(url));
+}
+
+function assertHostedOnPhotonInsecurely( url ) {
+  assert(RegExp('^http://i[0-2].wp.com').test(url));
+}
+
+function assertPathname ( url, expected ) {
+  var parsedUrl = parseUrl(url, true, true);
+  assert.strictEqual(parsedUrl.pathname, expected);
+}
+
+function assertQuery ( url, expected ) {
+  var query = parseUrl(url, true, true).query,
+    key;
+
+  assert.deepEqual(query, expected);
+}
 
 describe('photon()', function () {
 
   it('should be a "function"', function () {
-    assert('function' === typeof photon);
+    assert.strictEqual(typeof photon, 'function');
   });
 
   it('should Photon-ify a basic image URL', function () {
     var url = 'http://example.com/image.png';
+
     assert(RegExp('https://i[0-2].wp.com/example.com/image.png').test(photon(url)));
   });
 
-  it('should not Photon-ify a Photon URL', function () {
-    var url = 'https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
-    assert(photon(url) === url);
+  it('should not Photon-ify an existing Photon URL, even if the host is wrong', function () {
+    var photonedUrl = photon('http://www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc');
+    var alternateUrl = 'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
+
+    assertHostedOnPhoton(photonedUrl);
+    assert.notStrictEqual(alternateUrl, photonedUrl);
+    assert.strictEqual(alternateUrl, photon(alternateUrl));
+  });
+
+  it('should handle photoning a photoned url', function() {
+    var url = photon('http://example.com/image.png');
+    assert.strictEqual(url, photon(url));
+  });
+
+  it('should add width parameters if specified', function() {
+    var photonedUrl = photon('http://example.com/image.png', { width: 50 });
+    var parsedUrl = parseUrl(photonedUrl, true, true);
+
+    assertQuery(photonedUrl, { 'w':'50' });
+  });
+
+  it('should encode query args for non-photon hosts', function() {
+    var photonedUrl = photon('http://example.com/image.png?foo=bar');
+
+    assertPathname(photonedUrl, '/example.com/image.png%3Ffoo=bar');
+  });
+
+  it('should handle protocolless URLs', function() {
+    var url = '//example.com/image.png';
+    var photonedUrl = photon(url);
+
+    assertHostedOnPhoton( photonedUrl );
+    assertPathname(photonedUrl, '/example.com/image.png');
+  });
+
+  it('should strip existing size params from photoned URLs', function () {
+      var url = 'https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc?resize=120';
+      var photonedUrl = photon(url, { width: 150, height: 300 });
+
+      assertHostedOnPhoton(photonedUrl);
+      assertPathname(photonedUrl, '/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc');
+      assertQuery(photonedUrl, { w: '150', h: '300' });
+  });
+
+  it('should allow you to do everything at once', function() {
+    var url = 'https://i0.wp.com/example.com/foo.png?w=50&lb=10&unknown=true';
+    var photonedUrl = photon(url, {
+      width: 10,
+      height: 20,
+      letterboxing: '120,120',
+      removeLetterboxing: true
+    });
+
+    assertHostedOnPhoton( photonedUrl );
+    assertPathname( photonedUrl, '/example.com/foo.png' );
+    assertQuery( photonedUrl, { w: '10', h: '20', 'lb': '120,120', ulb: 'true' });
+  });
+
+  it('should allow you to turn off https', function() {
+    var photonedUrl = photon('http://example.com/foo.png', { secure: false });
+
+    assertHostedOnPhotonInsecurely(photonedUrl);
+
+    photonedUrl = photon('https://i0.wp.com/example.com/foo.png', { secure: false });
+
+    assertHostedOnPhotonInsecurely(photonedUrl);
   });
 });


### PR DESCRIPTION
Querystrings for photon using hosts were previously jammed into the pathname.
This teaches the url generator to strip them and insert new params based on the
options passed.

It also adds support for protocolless urls, which are becoming pretty common.

Last, it makes the inception handling for previously photoned URLs more robust,
and adds a number of tests to validate that the inception detection works.