### PR TITLE
Don't attempt to photon URLs that use a querystring.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ function photon (imageUrl, opts) {
     params.pathname = parsedUrl.pathname;
     params.hostname = parsedUrl.hostname;
   } else {
+    // Photon does not support URLs with a querystring component
+    if (parsedUrl.search ) {
+      return imageUrl;
+    }
     params.pathname = url.format( parsedUrl ).substring(1);
     params.hostname = serverFromPathname( params.pathname );
   }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function photon (imageUrl, opts) {
   } else {
     // Photon does not support URLs with a querystring component
     if (parsedUrl.search ) {
-      return imageUrl;
+      return null;
     }
     params.pathname = url.format( parsedUrl ).substring(1);
     params.hostname = serverFromPathname( params.pathname );
@@ -112,4 +112,3 @@ function serverFromPathname( pathname ) {
   debug('determined server "%s" to use with "%s"', server, pathname);
   return server + '.wp.com';
 }
-

--- a/test/test.js
+++ b/test/test.js
@@ -60,10 +60,10 @@ describe('photon()', function () {
     assertQuery(photonedUrl, { 'w':'50' });
   });
 
-  it('should leave URLs with querystrings from non-photon hosts alone', function() {
+  it('should return null for URLs with querystrings from non-photon hosts', function() {
     var url = 'http://example.com/image.png?foo=bar';
 
-    assert.strictEqual(photon(url), url);
+    assert.strictEqual(photon(url), null);
   });
 
   it('should handle protocolless URLs', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -44,13 +44,13 @@ describe('photon()', function () {
     var alternateUrl = 'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
 
     assertHostedOnPhoton(photonedUrl);
-    assert.notStrictEqual(alternateUrl, photonedUrl);
-    assert.strictEqual(alternateUrl, photon(alternateUrl));
+    assert.notStrictEqual(photonedUrl, alternateUrl);
+    assert.strictEqual(photon(alternateUrl), alternateUrl);
   });
 
   it('should handle photoning a photoned url', function() {
     var url = photon('http://example.com/image.png');
-    assert.strictEqual(url, photon(url));
+    assert.strictEqual(photon(url), url);
   });
 
   it('should add width parameters if specified', function() {
@@ -60,10 +60,10 @@ describe('photon()', function () {
     assertQuery(photonedUrl, { 'w':'50' });
   });
 
-  it('should encode query args for non-photon hosts', function() {
-    var photonedUrl = photon('http://example.com/image.png?foo=bar');
+  it('should leave URLs with querystrings from non-photon hosts alone', function() {
+    var url = 'http://example.com/image.png?foo=bar';
 
-    assertPathname(photonedUrl, '/example.com/image.png%3Ffoo=bar');
+    assert.strictEqual(photon(url), url);
   });
 
   it('should handle protocolless URLs', function() {


### PR DESCRIPTION
Photon doesn't support them.

Not sure this is the best approach. We could also try stripping the querystring, but that might lead to really broken results.

We could return null, to indicate the URL was not photon-able?