### PR TITLE
Add support for the ssl parameter to fetch images using https

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ var mappings = {
 function photon (imageUrl, opts) {
 
   // parse the URL, assuming //host.com/path style URLs are ok and parse the querystring
-  var parsedUrl = url.parse( imageUrl, true, true );
+  var parsedUrl = url.parse( imageUrl, true, true ),
+    wasSecure = parsedUrl.protocol === 'https:';
 
   delete parsedUrl.protocol;
   delete parsedUrl.auth;
@@ -50,7 +51,8 @@ function photon (imageUrl, opts) {
 
   var params = {
     slashes: true,
-    protocol: 'https:'
+    protocol: 'https:',
+    query: {}
   };
 
   if ( isAlreadyPhotoned( parsedUrl.host ) ) {
@@ -61,6 +63,9 @@ function photon (imageUrl, opts) {
   } else {
     params.pathname = url.format( parsedUrl ).substring(1);
     params.hostname = serverFromPathname( params.pathname );
+    if ( wasSecure ) {
+      params.query.ssl = 1;
+    }
   }
 
   if (opts) {
@@ -78,12 +83,12 @@ function photon (imageUrl, opts) {
         continue;
       }
 
-      // any other options just gets passed through as query-string parameters
-      if (!params.query) params.query = {};
-
       params.query[mappings[i] || i] = opts[i];
     }
   }
+
+  // do this after so a passed opt can't override it
+
 
   var photonUrl = url.format(params);
   debug('generated Photon URL: %s', photonUrl);
@@ -108,4 +113,3 @@ function serverFromPathname( pathname ) {
   debug('determined server "%s" to use with "%s"', server, pathname);
   return server + '.wp.com';
 }
-

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,11 @@ describe('photon()', function () {
     assert(RegExp('https://i[0-2].wp.com/example.com/image.png').test(photon(url)));
   });
 
+  it('should Photon-ify a secure image URL', function () {
+    var url = 'https://example.com/image.png';
+    assert(RegExp('https://i[0-2].wp.com/example.com/image.png\\\?ssl=1').test(photon(url)));
+  });
+
   it('should not Photon-ify an existing Photon URL, even if the host is wrong', function () {
     var photonedUrl = photon('http://www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc');
     var alternateUrl = 'https://i1.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc';
@@ -106,4 +111,17 @@ describe('photon()', function () {
 
     assertHostedOnPhotonInsecurely(photonedUrl);
   });
+
+  it('should allow you to turn off ssl for fetching', function() {
+    var photonedUrl = photon('https://example.com/foo.png', { secure: false, ssl: 0 });
+
+    assertHostedOnPhotonInsecurely(photonedUrl);
+    assertQuery(photonedUrl, { ssl: 0 });
+
+    photonedUrl = photon('https://i0.wp.com/example.com/foo.png', { secure: false, ssl: 0 });
+
+    assertHostedOnPhotonInsecurely(photonedUrl);
+    assertQuery(photonedUrl, { ssl: 0 });
+  });
+
 });


### PR DESCRIPTION
This is an undocumented parameter for photon that tells it to fetch the image over https instead of http. With all of the sites going secure-only, this is becoming pretty important to support.