### PR TITLE
Fix handling of "blob:" URLs on NodeJS 7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ node_js:
   - "3"
   - "4"
   - "5"
+  - "6"
+  - "7"
+  - "8"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function photon (imageUrl, opts) {
       return null;
     }
     var formattedUrl = url.format( parsedUrl );
-    params.pathname = formattedUrl.startsWith( '//' ) ? formattedUrl.substring(1) : formattedUrl;
+    params.pathname = 0 === formattedUrl.indexOf( '//' ) ? formattedUrl.substring(1) : formattedUrl;
     params.hostname = serverFromPathname( params.pathname );
     if ( wasSecure ) {
       params.query.ssl = 1;

--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ function photon (imageUrl, opts) {
     if (parsedUrl.search) {
       return null;
     }
-    params.pathname = url.format( parsedUrl ).substring(1);
+    var formattedUrl = url.format( parsedUrl );
+    params.pathname = formattedUrl.startsWith( '//' ) ? formattedUrl.substring(1) : formattedUrl;
     params.hostname = serverFromPathname( params.pathname );
     if ( wasSecure ) {
       params.query.ssl = 1;

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,14 @@ describe('photon()', function () {
     assertPathname(photonedUrl, '/example.com/image.png');
   });
 
+  it('should handle blob: URLs', function() {
+    var url = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+    var photonedUrl = photon(url);
+
+    assertHostedOnPhoton( photonedUrl );
+    assertPathname(photonedUrl, '/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71');
+  });
+
   it('should strip existing size params from photoned URLs', function () {
       var url = 'https://i0.wp.com/www.gravatar.com/avatar/693307b4e0cb9366f34862c9dfacd7fc?resize=120';
       var photonedUrl = photon(url, { width: 150, height: 300 });


### PR DESCRIPTION
This PR adds a test for transforming a `blob:` URL, that failed in
NodeJS 7 and 8 due to a change in the built-in `url.format` logic.
It also fixes the issue and adds targets for NodeJS 7 and 8
for TravisCI.