### PR TITLE
Deprecate and point to Calypso

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 
 It is now part of the [Calypso](https://github.com/Automattic/wp-calypso/tree/master/packages/photon) repository.
 
+The published npm package will continue to be available as before, no changes necessary!
 
 # photon.js
 [![Build Status](https://travis-ci.org/Automattic/photon.js.svg?branch=master)](https://travis-ci.org/Automattic/photon.js)

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # This repository has moved!
 
-It is not part of the [Calypso](https://github.com/Automattic/wp-calypso/tree/master/packages/photon) repository.
+It is now part of the [Calypso](https://github.com/Automattic/wp-calypso/tree/master/packages/photon) repository.
 
 
 # photon.js

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,8 @@
+# This repository has moved!
+
+It is not part of the [Calypso](https://github.com/Automattic/wp-calypso/tree/master/packages/photon) repository.
+
+
 # photon.js
 [![Build Status](https://travis-ci.org/Automattic/photon.js.svg?branch=master)](https://travis-ci.org/Automattic/photon.js)
 


### PR DESCRIPTION
This repository is being pulled into the Calypso repository.

See https://github.com/Automattic/wp-calypso/pull/29129