### PR TITLE
Add handling for WordPress.com files

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function photon (imageUrl, opts) {
     query: {}
   };
 
-  if ( isAlreadyPhotoned( parsedUrl.host ) ) {
+  if ( isWpcomImage( parsedUrl.host ) || isAlreadyPhotoned( parsedUrl.host ) ) {
     // We already have a server to use.
     // Use it, even if it doesn't match our hash.
     params.pathname = parsedUrl.pathname;
@@ -98,6 +98,10 @@ function photon (imageUrl, opts) {
   var photonUrl = url.format(params);
   debug('generated Photon URL: %s', photonUrl);
   return photonUrl;
+}
+
+function isWpcomImage( host ) {
+  return /\.files\.wordpress\.com$/.test(host)
 }
 
 function isAlreadyPhotoned( host ) {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function photon (imageUrl, opts) {
 }
 
 function isWpcomImage( host ) {
-  return /\.files\.wordpress\.com$/.test(host)
+  return /\.files\.wordpress\.com$/.test(host);
 }
 
 function isAlreadyPhotoned( host ) {

--- a/test/test.js
+++ b/test/test.js
@@ -58,12 +58,25 @@ describe('photon()', function () {
     assert.strictEqual(photon(url), url);
   });
 
+  it('should handle photoning a WordPress.com url', function() {
+    var url = photon('https://example.files.wordpress.com/2018/12/pexels-photo-1461974.jpeg');
+    assert.strictEqual(photon(url), url);
+  });
+
   it('should add width parameters if specified', function() {
     var photonedUrl = photon('http://example.com/image.png', { width: 50 });
     var parsedUrl = parseUrl(photonedUrl, true, true);
 
     assertQuery(photonedUrl, { 'w':'50' });
   });
+
+  it('should add width parameters to WordPress.com url if specified', function() {
+    var photonedUrl = photon('https://example.files.wordpress.com/2018/12/pexels-photo-1461974.jpeg', { width: 50 });
+    var parsedUrl = parseUrl(photonedUrl, true, true);
+
+    assertQuery(photonedUrl, { 'w':'50' });
+  });
+
 
   it('should return null for URLs with querystrings from non-photon hosts', function() {
     var url = 'http://example.com/image.png?foo=bar';


### PR DESCRIPTION
Jetpack's photon implementation includes special handling for `*.files.wordpress.com` URLs, which do not need to use a photon URL as this is _already_ a photon server.

Add special handling for `*.files.wordpress.com` URLs and related tests.

Here's the related Jetpack PHP implementation: https://github.com/Automattic/jetpack/blob/43629b97a6714774cbc0cf49012dda13196e9c21/functions.photon.php#L93-L101