### PR TITLE
Revert "Add handling for WordPress.com files"

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function photon (imageUrl, opts) {
     query: {}
   };
 
-  if ( isWpcomImage( parsedUrl.host ) || isAlreadyPhotoned( parsedUrl.host ) ) {
+  if ( isAlreadyPhotoned( parsedUrl.host ) ) {
     // We already have a server to use.
     // Use it, even if it doesn't match our hash.
     params.pathname = parsedUrl.pathname;
@@ -98,10 +98,6 @@ function photon (imageUrl, opts) {
   var photonUrl = url.format(params);
   debug('generated Photon URL: %s', photonUrl);
   return photonUrl;
-}
-
-function isWpcomImage( host ) {
-  return /\.files\.wordpress\.com$/.test(host);
 }
 
 function isAlreadyPhotoned( host ) {

--- a/test/test.js
+++ b/test/test.js
@@ -58,25 +58,12 @@ describe('photon()', function () {
     assert.strictEqual(photon(url), url);
   });
 
-  it('should handle photoning a WordPress.com url', function() {
-    var url = photon('https://example.files.wordpress.com/2018/12/pexels-photo-1461974.jpeg');
-    assert.strictEqual(photon(url), url);
-  });
-
   it('should add width parameters if specified', function() {
     var photonedUrl = photon('http://example.com/image.png', { width: 50 });
     var parsedUrl = parseUrl(photonedUrl, true, true);
 
     assertQuery(photonedUrl, { 'w':'50' });
   });
-
-  it('should add width parameters to WordPress.com url if specified', function() {
-    var photonedUrl = photon('https://example.files.wordpress.com/2018/12/pexels-photo-1461974.jpeg', { width: 50 });
-    var parsedUrl = parseUrl(photonedUrl, true, true);
-
-    assertQuery(photonedUrl, { 'w':'50' });
-  });
-
 
   it('should return null for URLs with querystrings from non-photon hosts', function() {
     var url = 'http://example.com/image.png?foo=bar';


### PR DESCRIPTION
Reverts Automattic/photon.js#10

This was giving us CORS issues in Calypso, so we had to revert the PR that bumped the `photon.js` version there (https://github.com/Automattic/wp-calypso/pull/30075). I'm assuming we should also revert here.